### PR TITLE
Use Django 1.6.7

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,1 @@
-Django==1.6
+Django==1.6.7


### PR DESCRIPTION
Django 1.6 doesn't work well with uWSGI on GetBarista causing ImproperlyConfigured error.
Version 1.6.7 woks fine.

In details:https://groups.google.com/forum/#!topic/django-users/pZAjYlmKIbA
